### PR TITLE
Handle repo's that don't have a master branch

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -20,7 +20,7 @@ var gTestDirectory;
 var gPullRequestFlag;
 var gFilterIssueLabels;
 var gKeywords;
-
+var gBranch;
 
 var loadIssues = function(callback) {
     
@@ -42,7 +42,7 @@ var loadIssues = function(callback) {
 
 var loadCommits = function (callback) {
 
-    sync.loadCommits(gCommits, gUrl, callback);
+    sync.loadCommits(gCommits, gUrl, gBranch, callback);
 };
 
 var analyseRepo = function (callback) {
@@ -97,6 +97,13 @@ module.exports.analyseRepo = function (config, callback, errback) {
     gPullRequestFlag = config.pullRequestFlag;
     gFilterIssueLabels = config.filterIssueLabels;
     gKeywords = config.filterIssueKeywords;
+
+    if (config.branch == undefined) {
+        gBranch = "master";
+    } else {
+        gBranch = config.branch;
+    }
+
 
     async.series([loadIssues, loadCommits, analyseRepo, generateGraph], function(err) {
         

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ var yargs = require("yargs")
     .alias("z", "pullrequest")
     .alias("l", "filterissues")
     .alias("k", "keywords")
+    .alias("b", "branch")
     .alias("h", "help")
     .describe("u", "GitHub username")
     .describe("p", "GitHub password")
@@ -19,6 +20,7 @@ var yargs = require("yargs")
     .describe("z", "Include pull requests (y/n)")
     .describe("l", "Filter issues by given label(s)")
     .describe("k", "Filter issues by keyword(s) search")
+    .describe("b", "Branch to analyse (default is master)")
     .describe("h", "Show the help menu");
 
 var argv = yargs.argv;
@@ -36,6 +38,7 @@ var gTestDirectory;
 var gPullRequestFlag;
 var gFilterIssueLabels;
 var gKeywords;
+var gBranch;
 
 var gPlotlyGraphId;
 
@@ -82,6 +85,11 @@ var promptArguments = function(callback) {
             description: "Filter issues by keyword(s) search",
             pattern: /^([a-zA-Z]+)(,\s[a-zA-Z]+)*$/,
             message: "specify keywords separated by comma's ex. ('UI, view, heatmap')"
+        },
+        {
+            name: "branch",
+            description: "Branch to analyse (default: master)",
+            message: "Specify what branch to analyse"
         }
     ];
 
@@ -130,6 +138,10 @@ var promptArguments = function(callback) {
             gKeywords = gKeywords.toUpperCase();
             gKeywords = gKeywords.split(", ");
 	    }
+
+        if (result.branch) {
+            gBranch = result.branch;
+        }
 	    
         callback();
     });
@@ -144,7 +156,8 @@ var analyseRepo = function(callback) {
         testDirectory: gTestDirectory,
         pullRequestFlag: gPullRequestFlag,
         filterIssueLabels: gFilterIssueLabels,
-        filterIssueKeywords: gKeywords
+        filterIssueKeywords: gKeywords,
+        branch: gBranch
     };
 
     core.analyseRepo(config, function(response) {

--- a/src/server.js
+++ b/src/server.js
@@ -40,7 +40,8 @@ io.on("connection", function(socket) {
             testDirectory: data.testDir,
             pullRequestFlag: data.pullRequest,
             filterIssueLabels: labels,
-            filterIssueKeywords: keywords
+            filterIssueKeywords: keywords,
+            branch: data.branch
         };
 
         core.analyseRepo(config, function(response) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -7,9 +7,11 @@ var moment = require("moment");
 //Initialize globals
 var gCommits = [];
 var gUrl;
+var gBranch;
 
 var scrapeCommits = function (firstCommitOnMaster, callback) {
    
+    console.log("Scrape commits");
     var history = firstCommitOnMaster.history();
     
     history.on("commit", function (commit) { 
@@ -53,11 +55,11 @@ var loadRepoHistory = function (callback) {
                 }, function (err) { console.error(err); return;})
 
                 .then(function () {
-                    return repository.mergeBranches("master", "origin/master");
+                    return repository.mergeBranches(gBranch, "origin/" + gBranch);
                 }, function (err) {console.error(err); return;})
 
                 .then(function () {
-                    return repository.getMasterCommit();
+                    return repository.getBranchCommit(gBranch);
                 })
 
                 .then(function (firstCommitOnMaster) {
@@ -74,7 +76,7 @@ var loadRepoHistory = function (callback) {
             nodegit.Clone.clone(gUrl, repo_path, { ignoreCertErrors: 1})
 
                 .then(function (repo) {
-                    return repo.getMasterCommit();
+                    return repo.getBranchCommit(gBranch);
                 }, function (err) { console.error(err); return;})
 
                 .then(function (firstCommitOnMaster) {
@@ -85,8 +87,9 @@ var loadRepoHistory = function (callback) {
 };
 
 
-module.exports.loadCommits = function (coms, url, callback) {
+module.exports.loadCommits = function (coms, url, branch, callback) {
     gCommits = coms;
     gUrl = url;
+    gBranch = branch;
     loadRepoHistory(callback);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,6 +98,9 @@
           <label for="repoTestDir" class="sr-only">GitHub Repository Test Directory</label>
           <input type="text" id="repoTestDir" class="form-control" placeholder="Repository Test Directory" required autofocus>
 
+          <label for="repoBranch" class="sr-only">Branch to Analyse</label>
+          <input type="text" id="repoBranch" class="form-control" placeholder="Branch to analyse (default: master)" required autofocus>
+
           <label for="keywords" class="sr-only">Filter Issues by Keywords (ex. bug, UI, defect)</label>
           <input type="text" id="keywords" class="form-control" placeholder="Filter Issues by Keywords (ex. bug, defect)" required autofocus> 
           <div class="labels"></div>

--- a/templates/js/index.js
+++ b/templates/js/index.js
@@ -126,10 +126,12 @@ function submitAnalyzeRepo(form) {
     AnalyzeRepo.labels = getLabels();
     AnalyzeRepo.keywords =  form.find("input#keywords").val();
     AnalyzeRepo.pullRequest = getPullRequest();    
+    AnalyzeRepo.branch = form.find("#repoBranch").val();
 
 
     if (AnalyzeRepo.labels == "") AnalyzeRepo.labels = undefined;
     if (AnalyzeRepo.keywords == "") AnalyzeRepo.keywords = undefined;
+    if (AnalyzeRepo.branch == "") AnalyzeRepo.branch = undefined;
 
     
 


### PR DESCRIPTION
Fix an issue where analysis would hang if a project didn't have a master branch. Add options for specifying the branch, keep the default as master. 
