### PR TITLE
Use the absolute value for derivative.

### DIFF
--- a/src/analyser.js
+++ b/src/analyser.js
@@ -308,7 +308,7 @@ var processData = function(callback) {
         
             lineCount = linesOfCode[i];
             
-            linesOfCodeDerivative.push(lineCount - prevLineCount);
+            linesOfCodeDerivative.push(Math.abs(lineCount - prevLineCount));
             
             prevLineCount = lineCount;
         }


### PR DESCRIPTION
This accomplishes two things:

```
1. The plotly graph y-axises have the
   same zero, so it's easier to read off
   the graph
2. We had talked about using absolute
   value anyways, because we care about
   the amount of changes, not whether
   they we additions or deletions
```
